### PR TITLE
feat: support oon and openia app keys

### DIFF
--- a/src/routers/seedRouter.js
+++ b/src/routers/seedRouter.js
@@ -29,7 +29,8 @@ const {
 } = require("../utils/helpers");
 
 const seed = async (req, res) => {
-  const { baseOmie, appKey_central_oon, appKey_openIa, appKey_sendgrid } = req.body;
+  const { baseOmie, appKey_central_oon, appKey_openIa, appKey_sendgrid } =
+    req.body;
 
   const baseOmieExistente = await BaseOmie.findOne();
   if (baseOmieExistente) {
@@ -40,7 +41,7 @@ const seed = async (req, res) => {
     });
   }
 
-  if (!baseOmie || !appKey_central_oon) {
+  if (!baseOmie || !appKey_central_oon || !appKey_openIa) {
     return sendErrorResponse({
       res,
       statusCode: 400,

--- a/src/seeds/sistemas.json
+++ b/src/seeds/sistemas.json
@@ -5,6 +5,7 @@
       "email": "suporte@oondemand.com.br"
     },
     "appKey_sendgrid": "SG.",
-    "appKey_central_oon": "oon_"
+    "appKey_central_oon": "oon_",
+    "appKey_openIa": "open_"
   }
 ]


### PR DESCRIPTION
## Summary
- require `appKey_central_oon` and `appKey_openIa` when seeding
- add `appKey_openIa` to sistemas seed data

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c055464e60832f883f1cfe5c0da704