### PR TITLE
fix: configure sendgrid via core Sistema

### DIFF
--- a/src/utils/emailUtils.js
+++ b/src/utils/emailUtils.js
@@ -5,14 +5,14 @@ const { conviteTemplate } = require("../constants/template");
 
 const enviarEmail = async (emailTo, assunto, corpo, anexos = []) => {
   const config = await Sistema.findOne();
-  const currentApiKey = config?.appKey_sendgrid;
-
-  sgMail.setApiKey(currentApiKey);
+  sgMail.setApiKey(config?.appKey_sendgrid);
+  const remetenteEmail = config?.remetente?.email;
+  const remetenteNome = config?.remetente?.nome ?? remetenteEmail;
 
   const message = {
     from: {
-      email: config?.remetente?.email,
-      name: config?.remetente?.nome ?? config?.remetente?.email,
+      email: remetenteEmail,
+      name: remetenteNome,
     },
     personalizations: [
       {


### PR DESCRIPTION
## Summary
- load Sistema from core and configure SendGrid using `appKey_sendgrid`
- ensure sender fields are derived from `remetente`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c05687c168832fa1b3d59197421dff