### PR TITLE
chore: import Sistema from core

### DIFF
--- a/src/services/servicoTomadoTicket/aprovar.js
+++ b/src/services/servicoTomadoTicket/aprovar.js
@@ -6,6 +6,7 @@ const ContaPagarSync = require("../contaPagar/omie");
 const { add } = require("date-fns");
 const { randomUUID } = require("crypto");
 const ServicoService = require("../servico");
+const { Sistema } = require("central-oon-core-backend");
 
 const alterarEtapa = async ({ ticket, etapa }) => {
   ticket.etapa = etapa;


### PR DESCRIPTION
## Summary
- import Sistema from core so service can access configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node - <<'NODE'
const Sistema = require('./central-oon-core-backend/src/models/Sistema');
const doc = new Sistema();
doc.config = { omie: { foo: 'bar' }, other: 123 };
doc.markModified('config');
console.log('omie foo:', doc.config.omie.foo);
console.log('other:', doc.config.other);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68c05a8eb260832f9a9e7ea02e1b3f01