### PR TITLE
refactor: use shared http client for app authentication

### DIFF
--- a/central-oon-core-backend/src/middlewares/authMiddleware.js
+++ b/central-oon-core-backend/src/middlewares/authMiddleware.js
@@ -1,4 +1,7 @@
-const axios = require('axios');
+const createHttpClient = require('../config/httpClient');
+const apiMeusApps = createHttpClient({
+  baseURL: process.env.MEUS_APPS_BACKEND_URL,
+});
 const { sendErrorResponse } = require('../utils/response');
 
 const authMiddleware = async (req, res, next) => {
@@ -13,14 +16,11 @@ const authMiddleware = async (req, res, next) => {
   }
 
   try {
-    const response = await axios.get(
-      `${process.env.MEUS_APPS_BACKEND_URL}/auth/autenticar-aplicativo/`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    );
+    const response = await apiMeusApps.get('/auth/autenticar-aplicativo/', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
 
     const usuario = {
       tipo:

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -1,4 +1,7 @@
-const axios = require("axios");
+const createHttpClient = require("../../central-oon-core-backend/src/config/httpClient");
+const apiMeusApps = createHttpClient({
+  baseURL: process.env.MEUS_APPS_BACKEND_URL,
+});
 const Helpers = require("../utils/helpers");
 
 function authMiddleware({ getOrigin }) {
@@ -15,8 +18,8 @@ function authMiddleware({ getOrigin }) {
 
     try {
       const origin = await getOrigin();
-      const response = await axios.get(
-        `${process.env.MEUS_APPS_BACKEND_URL}/auth/autenticar-aplicativo/`,
+      const response = await apiMeusApps.get(
+        "/auth/autenticar-aplicativo/",
         {
           headers: {
             Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- use shared http client in core auth middleware
- use shared http client in project auth middleware

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c07464616c832faf3caa0a5892012d