### PR TITLE
feat: add auth module and local core replacements

### DIFF
--- a/central-oon-core-backend/src/auth/index.js
+++ b/central-oon-core-backend/src/auth/index.js
@@ -1,0 +1,83 @@
+const createHttpClient = require('../config/httpClient');
+const authMiddleware = require('../middlewares/authMiddleware');
+
+const api = createHttpClient({
+  baseURL: process.env.MEUS_APPS_BACKEND_URL,
+});
+
+/**
+ * Realiza o login do usuário utilizando o serviço central de autenticação.
+ * @param {Object} params
+ * @param {string} params.email
+ * @param {string} params.senha
+ * @param {string} params.origin
+ */
+async function login({ email, senha, origin }) {
+  const { data } = await api.post(
+    '/auth/login',
+    { email, senha },
+    { headers: { origin } },
+  );
+  return data;
+}
+
+/**
+ * Valida um token JWT junto ao serviço central de autenticação.
+ * @param {Object} params
+ * @param {string} params.token
+ * @param {string} params.origin
+ */
+async function validateToken({ token, origin }) {
+  const { data } = await api.get('/auth/validar-token', {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      origin,
+    },
+  });
+  return data;
+}
+
+/**
+ * Solicita a recuperação de senha para o e-mail informado.
+ * @param {Object} params
+ * @param {string} params.email
+ * @param {string} params.origin
+ */
+async function recoverPassword({ email, origin }) {
+  const { data } = await api.post(
+    '/auth/esqueci-minha-senha',
+    { email },
+    { headers: { origin } },
+  );
+  return data;
+}
+
+/**
+ * Altera a senha do usuário utilizando token de autorização.
+ * @param {Object} params
+ * @param {string} params.token
+ * @param {string} params.senhaAtual
+ * @param {string} params.novaSenha
+ * @param {string} params.origin
+ */
+async function changePassword({ token, senhaAtual, novaSenha, origin }) {
+  const { data } = await api.post(
+    '/auth/alterar-senha',
+    { senhaAtual, novaSenha },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        origin,
+      },
+    },
+  );
+  return data;
+}
+
+module.exports = {
+  login,
+  validateToken,
+  recoverPassword,
+  changePassword,
+  authMiddleware,
+};

--- a/central-oon-core-backend/src/index.js
+++ b/central-oon-core-backend/src/index.js
@@ -1,29 +1,18 @@
 const dotenv = require('dotenv');
 dotenv.config();
 
-const createApp = require('./boot/createApp');
-const createServer = require('./boot/createServer');
-const logger = require('./config/logger');
-const { uploadExcel, uploadPDF } = require('./config/multer');
-const createHttpClient = require('./config/httpClient');
-const GenericError = require('./errors/GenericError');
-const authMiddleware = require('./middlewares/authMiddleware');
-const errorMiddleware = require('./middlewares/errorMiddleware');
-const logMiddleware = require('./middlewares/logMiddleware');
-const Log = require('./models/Log');
-const { sendErrorResponse } = require('./utils/response');
+const {
+  login,
+  validateToken,
+  recoverPassword,
+  changePassword,
+  authMiddleware,
+} = require('./auth');
 
 module.exports = {
-  createApp,
-  createServer,
-  logger,
-  uploadExcel,
-  uploadPDF,
-  createHttpClient,
-  GenericError,
+  login,
+  validateToken,
+  recoverPassword,
+  changePassword,
   authMiddleware,
-  errorMiddleware,
-  logMiddleware,
-  Log,
-  sendErrorResponse,
 };

--- a/src/config/db.js
+++ b/src/config/db.js
@@ -1,0 +1,34 @@
+const mongoose = require("mongoose");
+
+const config = {
+  dbServer: process.env.DB_SERVER,
+  dbUser: process.env.DB_USER,
+  dbPassword: process.env.DB_PASSWORD,
+  dbName: process.env.DB_NAME,
+  dbAuthSource: process.env.DB_AUTH_SOURCE,
+  dbReplicaSet: process.env.DB_REPLICA_SET,
+  dbTsl: process.env.DB_TSL,
+};
+
+let mongoUri = `${config.dbServer}/${config.dbName}?`;
+if (config.dbAuthSource) mongoUri += `authSource=${config.dbAuthSource}&`;
+if (config.dbTsl) mongoUri += `tls=true&`;
+if (config.dbReplicaSet) mongoUri += `replicaSet=${config.dbReplicaSet}`;
+
+const connectDB = async () => {
+  try {
+    await mongoose.connect(mongoUri, {
+      user: config.dbUser,
+      pass: config.dbPassword,
+    });
+    console.log(`Conectado ao MongoDB`);
+    console.log(` - Server: ${config.dbServer}`);
+    console.log(` - User: ${config.dbUser}`);
+    console.log(` - Database: ${config.dbName}`);
+  } catch (err) {
+    console.error(`Erro ao conectar ao MongoDB ${config.dbName}`, err);
+    process.exit(1);
+  }
+};
+
+module.exports = connectDB;

--- a/src/config/httpClient.js
+++ b/src/config/httpClient.js
@@ -1,0 +1,20 @@
+const axios = require("axios");
+
+/**
+ * Cria uma instância configurada do Axios.
+ * @param {Object} options
+ * @param {string} options.baseURL - URL base para as requisições.
+ * @param {number} [options.timeout=30000] - Tempo limite em milissegundos.
+ * @returns {import('axios').AxiosInstance}
+ */
+const createHttpClient = ({ baseURL, timeout = 30000 } = {}) => {
+  return axios.create({
+    baseURL,
+    timeout,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+};
+
+module.exports = createHttpClient;

--- a/src/config/multer.js
+++ b/src/config/multer.js
@@ -1,0 +1,38 @@
+const multer = require("multer");
+
+const uploadExcel = multer({
+  storage: multer.memoryStorage({}),
+  fileFilter: (req, file, cb) => {
+    const tiposPermitidos = [
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "application/vnd.ms-excel",
+      "application/vnd.ms-excel.sheet.binary.macroenabled.12",
+    ];
+
+    if (tiposPermitidos.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error("Tipo de arquivo não suportado"), false);
+    }
+  },
+  limits: { fileSize: 20 * 1024 * 1024 }, // Limite de 20MB
+});
+
+const uploadPDF = multer({
+  storage: multer.memoryStorage(),
+  fileFilter: (req, file, cb) => {
+    const tipoPDF = "application/pdf";
+
+    if (file.mimetype === tipoPDF) {
+      cb(null, true);
+    } else {
+      cb(new Error("Apenas arquivos PDF são permitidos"), false);
+    }
+  },
+  limits: { fileSize: 2 * 1024 * 1024 }, // Limite de 2MB
+});
+
+module.exports = {
+  uploadExcel,
+  uploadPDF,
+};

--- a/src/middlewares/errorMiddleware.js
+++ b/src/middlewares/errorMiddleware.js
@@ -1,0 +1,43 @@
+const multer = require('multer');
+const GenericError = require('../services/errors/generic');
+const { sendErrorResponse } = require('../utils/helpers');
+
+const errorMiddleware = (error, _, res, next) => {
+  if (!error) return next();
+
+  if (error instanceof multer.MulterError) {
+    if (error.code === 'LIMIT_FILE_SIZE') {
+      return sendErrorResponse({
+        res,
+        statusCode: 513,
+        error: error.message,
+        message: 'O arquivo enviado excede o tamanho máximo permitido!',
+      });
+    }
+
+    return sendErrorResponse({
+      res,
+      statusCode: 500,
+      error: error.message,
+      message: 'Houve um erro inesperado!',
+    });
+  }
+
+  if (error instanceof GenericError) {
+    return sendErrorResponse({
+      res,
+      statusCode: error.statusCode,
+      error: error.details,
+      message: error.message,
+    });
+  }
+
+  return sendErrorResponse({
+    res,
+    statusCode: 500,
+    error: error.message,
+    message: 'Houve um erro inesperado!',
+  });
+};
+
+module.exports = errorMiddleware;

--- a/src/routers/authRouter.js
+++ b/src/routers/authRouter.js
@@ -1,22 +1,53 @@
 const express = require("express");
 const router = express.Router();
-const UsuarioController = require("../controllers/usuario");
-const { authMiddleware } = require("central-oon-core-backend");
+const {
+  authMiddleware,
+  login,
+  validateToken,
+  recoverPassword,
+  changePassword,
+} = require("central-oon-core-backend");
 const { asyncHandler } = require("../utils/helpers");
 const Sistema = require("../models/Sistema");
 const getOrigin = async () => (await Sistema.findOne())?.appKey;
 
-router.post("/login", asyncHandler(UsuarioController.loginUsuario));
+router.post(
+  "/login",
+  asyncHandler(async (req, res) => {
+    const origin = await getOrigin();
+    const data = await login({ ...req.body, origin });
+    res.status(200).json(data);
+  })
+);
+
 router.get(
   "/validar-token",
   authMiddleware({ getOrigin }),
-  asyncHandler(UsuarioController.validarToken)
+  asyncHandler(async (req, res) => {
+    const origin = await getOrigin();
+    const token = req.headers.authorization?.split(" ")[1];
+    const data = await validateToken({ token, origin });
+    res.status(200).json(data);
+  })
 );
 
 router.post(
   "/esqueci-minha-senha",
-  asyncHandler(UsuarioController.esqueciMinhaSenha)
+  asyncHandler(async (req, res) => {
+    const origin = await getOrigin();
+    const data = await recoverPassword({ ...req.body, origin });
+    res.status(200).json(data);
+  })
 );
 
-router.post("/alterar-senha", asyncHandler(UsuarioController.alterarSenha));
+router.post(
+  "/alterar-senha",
+  asyncHandler(async (req, res) => {
+    const origin = await getOrigin();
+    const token = req.headers.authorization?.split(" ")[1];
+    const data = await changePassword({ ...req.body, token, origin });
+    res.status(200).json(data);
+  })
+);
+
 module.exports = router;

--- a/src/routers/documentoCadastralRouter.js
+++ b/src/routers/documentoCadastralRouter.js
@@ -3,7 +3,7 @@ const DocumentoCadastralController = require("../controllers/documentoCadastral"
 
 const router = express.Router();
 
-const { uploadExcel, uploadPDF } = require("central-oon-core-backend");
+const { uploadExcel, uploadPDF } = require("../config/multer");
 const {
   registrarAcaoMiddleware,
 } = require("../middlewares/registrarAcaoMiddleware");

--- a/src/routers/documentoFiscalRouter.js
+++ b/src/routers/documentoFiscalRouter.js
@@ -3,7 +3,7 @@ const DocumentoFiscalController = require("../controllers/documentoFiscal");
 
 const router = express.Router();
 
-const { uploadExcel, uploadPDF } = require("central-oon-core-backend");
+const { uploadExcel, uploadPDF } = require("../config/multer");
 const {
   registrarAcaoMiddleware,
 } = require("../middlewares/registrarAcaoMiddleware");

--- a/src/routers/moedaRouter.js
+++ b/src/routers/moedaRouter.js
@@ -6,7 +6,7 @@ const {
 const router = express.Router();
 const { asyncHandler } = require("../utils/helpers");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
-const { uploadExcel } = require("central-oon-core-backend");
+const { uploadExcel } = require("../config/multer");
 
 router.get("/", asyncHandler(MoedaController.listarComPaginacao));
 router.get("/ativas", asyncHandler(MoedaController.listarAtivas));

--- a/src/routers/pessoaRouter.js
+++ b/src/routers/pessoaRouter.js
@@ -6,7 +6,7 @@ const {
 const router = express.Router();
 const { asyncHandler } = require("../utils/helpers");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
-const { uploadExcel } = require("central-oon-core-backend");
+const { uploadExcel } = require("../config/multer");
 
 router.get("/", asyncHandler(PessoaController.listar));
 

--- a/src/routers/servicoRouter.js
+++ b/src/routers/servicoRouter.js
@@ -6,7 +6,7 @@ const {
 const router = express.Router();
 const { asyncHandler } = require("../utils/helpers");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
-const { uploadExcel } = require("central-oon-core-backend");
+const { uploadExcel } = require("../config/multer");
 
 router.get("/", asyncHandler(ServicoController.listar));
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,26 @@
 const app = require("./app");
-const { createServer } = require("central-oon-core-backend");
+const connectDB = require("./config/db");
 
-createServer(app);
+const port = process.env.PORT || 4000;
+const serviceName = process.env.SERVICE_NAME;
+
+const startServer = async () => {
+  try {
+    console.log("Testando conexão com o Banco de Dados...");
+    await connectDB();
+
+    app.listen(port, () => {
+      console.log("****************************************************************");
+      console.log(
+        `${serviceName} rodando na porta ${port} e conectado ao MongoDB`
+      );
+      console.log("****************************************************************");
+      console.log("");
+    });
+  } catch (error) {
+    console.error("Falha ao iniciar o servidor:", error);
+    process.exit(1);
+  }
+};
+
+startServer();

--- a/src/services/omie/anexosService.js
+++ b/src/services/omie/anexosService.js
@@ -1,5 +1,5 @@
 const { compactFile } = require("../../utils/fileHandler");
-const { createHttpClient } = require("central-oon-core-backend");
+const createHttpClient = require("../../config/httpClient");
 
 const apiOmie = createHttpClient({ baseURL: process.env.API_OMIE });
 

--- a/src/services/omie/categoriasService.js
+++ b/src/services/omie/categoriasService.js
@@ -1,4 +1,4 @@
-const { createHttpClient } = require("central-oon-core-backend");
+const createHttpClient = require("../../config/httpClient");
 
 const apiOmie = createHttpClient({ baseURL: process.env.API_OMIE });
 

--- a/src/services/omie/clienteService.js
+++ b/src/services/omie/clienteService.js
@@ -1,4 +1,4 @@
-const { createHttpClient } = require("central-oon-core-backend");
+const createHttpClient = require("../../config/httpClient");
 
 const apiOmie = createHttpClient({ baseURL: process.env.API_OMIE });
 

--- a/src/services/omie/contaCorrenteService.js
+++ b/src/services/omie/contaCorrenteService.js
@@ -1,4 +1,4 @@
-const { createHttpClient } = require("central-oon-core-backend");
+const createHttpClient = require("../../config/httpClient");
 
 const apiOmie = createHttpClient({ baseURL: process.env.API_OMIE });
 

--- a/src/services/omie/contaPagarService.js
+++ b/src/services/omie/contaPagarService.js
@@ -1,5 +1,5 @@
 const crypto = require("crypto");
-const { createHttpClient } = require("central-oon-core-backend");
+const createHttpClient = require("../../config/httpClient");
 
 const { formatarDataOmie } = require("../../utils/dateUtils");
 

--- a/src/services/omie/listasOmie.js
+++ b/src/services/omie/listasOmie.js
@@ -1,4 +1,4 @@
-const { createHttpClient } = require("central-oon-core-backend");
+const createHttpClient = require("../../config/httpClient");
 
 const apiOmie = createHttpClient({ baseURL: process.env.API_OMIE });
 


### PR DESCRIPTION
## Summary
- add auth module with login, token validation, password recovery and change endpoints in core
- export auth functions and middleware in core index
- replace core dependencies with local implementations and use only auth module

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c18db0771c832fb0236bfe33df3cd0