### PR TITLE
feat: centralize auth routing in core

### DIFF
--- a/central-oon-core-backend/package.json
+++ b/central-oon-core-backend/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "axios": "^1.7.7",
     "dotenv": "^16.4.5",
+    "express": "^4.21.2",
     "multer": "^1.4.5-lts.1",
     "winston": "^3.17.0"
   }

--- a/central-oon-core-backend/src/auth/index.js
+++ b/central-oon-core-backend/src/auth/index.js
@@ -1,78 +1,11 @@
-const createHttpClient = require('../config/httpClient');
+const {
+  login,
+  validateToken,
+  recoverPassword,
+  changePassword,
+} = require('./service');
 const authMiddleware = require('../middlewares/authMiddleware');
-
-const api = createHttpClient({
-  baseURL: process.env.MEUS_APPS_BACKEND_URL,
-});
-
-/**
- * Realiza o login do usuário utilizando o serviço central de autenticação.
- * @param {Object} params
- * @param {string} params.email
- * @param {string} params.senha
- * @param {string} params.origin
- */
-async function login({ email, senha, origin }) {
-  const { data } = await api.post(
-    '/auth/login',
-    { email, senha },
-    { headers: { origin } },
-  );
-  return data;
-}
-
-/**
- * Valida um token JWT junto ao serviço central de autenticação.
- * @param {Object} params
- * @param {string} params.token
- * @param {string} params.origin
- */
-async function validateToken({ token, origin }) {
-  const { data } = await api.get('/auth/validar-token', {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      origin,
-    },
-  });
-  return data;
-}
-
-/**
- * Solicita a recuperação de senha para o e-mail informado.
- * @param {Object} params
- * @param {string} params.email
- * @param {string} params.origin
- */
-async function recoverPassword({ email, origin }) {
-  const { data } = await api.post(
-    '/auth/esqueci-minha-senha',
-    { email },
-    { headers: { origin } },
-  );
-  return data;
-}
-
-/**
- * Altera a senha do usuário utilizando token de autorização.
- * @param {Object} params
- * @param {string} params.token
- * @param {string} params.senhaAtual
- * @param {string} params.novaSenha
- * @param {string} params.origin
- */
-async function changePassword({ token, senhaAtual, novaSenha, origin }) {
-  const { data } = await api.post(
-    '/auth/alterar-senha',
-    { senhaAtual, novaSenha },
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        origin,
-      },
-    },
-  );
-  return data;
-}
+const authRouter = require('./router');
 
 module.exports = {
   login,
@@ -80,4 +13,5 @@ module.exports = {
   recoverPassword,
   changePassword,
   authMiddleware,
+  authRouter,
 };

--- a/central-oon-core-backend/src/auth/router.js
+++ b/central-oon-core-backend/src/auth/router.js
@@ -1,0 +1,61 @@
+const express = require('express');
+const {
+  login,
+  validateToken,
+  recoverPassword,
+  changePassword,
+} = require('./service');
+const authMiddleware = require('../middlewares/authMiddleware');
+
+function asyncHandler(fn) {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+function authRouter({ getOrigin }) {
+  const router = express.Router();
+
+  router.post(
+    '/login',
+    asyncHandler(async (req, res) => {
+      const origin = await getOrigin();
+      const data = await login({ ...req.body, origin });
+      res.status(200).json(data);
+    }),
+  );
+
+  router.get(
+    '/validar-token',
+    authMiddleware({ getOrigin }),
+    asyncHandler(async (req, res) => {
+      const origin = await getOrigin();
+      const token = req.headers.authorization?.split(' ')[1];
+      const data = await validateToken({ token, origin });
+      res.status(200).json(data);
+    }),
+  );
+
+  router.post(
+    '/esqueci-minha-senha',
+    asyncHandler(async (req, res) => {
+      const origin = await getOrigin();
+      const data = await recoverPassword({ ...req.body, origin });
+      res.status(200).json(data);
+    }),
+  );
+
+  router.post(
+    '/alterar-senha',
+    asyncHandler(async (req, res) => {
+      const origin = await getOrigin();
+      const token = req.headers.authorization?.split(' ')[1];
+      const data = await changePassword({ ...req.body, token, origin });
+      res.status(200).json(data);
+    }),
+  );
+
+  return router;
+}
+
+module.exports = authRouter;

--- a/central-oon-core-backend/src/auth/service.js
+++ b/central-oon-core-backend/src/auth/service.js
@@ -1,0 +1,81 @@
+const createHttpClient = require('../config/httpClient');
+
+const api = createHttpClient({
+  baseURL: process.env.MEUS_APPS_BACKEND_URL,
+});
+
+/**
+ * Realiza o login do usuário utilizando o serviço central de autenticação.
+ * @param {Object} params
+ * @param {string} params.email
+ * @param {string} params.senha
+ * @param {string} params.origin
+ */
+async function login({ email, senha, origin }) {
+  const { data } = await api.post(
+    '/auth/login',
+    { email, senha },
+    { headers: { origin } },
+  );
+  return data;
+}
+
+/**
+ * Valida um token JWT junto ao serviço central de autenticação.
+ * @param {Object} params
+ * @param {string} params.token
+ * @param {string} params.origin
+ */
+async function validateToken({ token, origin }) {
+  const { data } = await api.get('/auth/validar-token', {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      origin,
+    },
+  });
+  return data;
+}
+
+/**
+ * Solicita a recuperação de senha para o e-mail informado.
+ * @param {Object} params
+ * @param {string} params.email
+ * @param {string} params.origin
+ */
+async function recoverPassword({ email, origin }) {
+  const { data } = await api.post(
+    '/auth/esqueci-minha-senha',
+    { email },
+    { headers: { origin } },
+  );
+  return data;
+}
+
+/**
+ * Altera a senha do usuário utilizando token de autorização.
+ * @param {Object} params
+ * @param {string} params.token
+ * @param {string} params.senhaAtual
+ * @param {string} params.novaSenha
+ * @param {string} params.origin
+ */
+async function changePassword({ token, senhaAtual, novaSenha, origin }) {
+  const { data } = await api.post(
+    '/auth/alterar-senha',
+    { senhaAtual, novaSenha },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        origin,
+      },
+    },
+  );
+  return data;
+}
+
+module.exports = {
+  login,
+  validateToken,
+  recoverPassword,
+  changePassword,
+};

--- a/central-oon-core-backend/src/index.js
+++ b/central-oon-core-backend/src/index.js
@@ -7,6 +7,7 @@ const {
   recoverPassword,
   changePassword,
   authMiddleware,
+  authRouter,
 } = require('./auth');
 
 module.exports = {
@@ -15,4 +16,5 @@ module.exports = {
   recoverPassword,
   changePassword,
   authMiddleware,
+  authRouter,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
       "dependencies": {
         "axios": "^1.7.7",
         "dotenv": "^16.4.5",
+        "express": "^4.21.2",
         "multer": "^1.4.5-lts.1",
         "winston": "^3.17.0"
       }
@@ -1146,14 +1147,7 @@
     },
     "node_modules/central-oon-core-backend": {
       "resolved": "central-oon-core-backend",
-      "link": true,
-      "version": "0.0.2",
-      "dependencies": {
-        "axios": "^1.7.7",
-        "dotenv": "^16.4.5",
-        "multer": "^1.4.5-lts.1",
-        "winston": "^3.17.0"
-      }
+      "link": true
     },
     "node_modules/cfb": {
       "version": "1.2.2",

--- a/src/routers/authRouter.js
+++ b/src/routers/authRouter.js
@@ -1,53 +1,6 @@
-const express = require("express");
-const router = express.Router();
-const {
-  authMiddleware,
-  login,
-  validateToken,
-  recoverPassword,
-  changePassword,
-} = require("central-oon-core-backend");
-const { asyncHandler } = require("../utils/helpers");
-const Sistema = require("../models/Sistema");
+const { authRouter } = require('central-oon-core-backend');
+const Sistema = require('../models/Sistema');
+
 const getOrigin = async () => (await Sistema.findOne())?.appKey;
 
-router.post(
-  "/login",
-  asyncHandler(async (req, res) => {
-    const origin = await getOrigin();
-    const data = await login({ ...req.body, origin });
-    res.status(200).json(data);
-  })
-);
-
-router.get(
-  "/validar-token",
-  authMiddleware({ getOrigin }),
-  asyncHandler(async (req, res) => {
-    const origin = await getOrigin();
-    const token = req.headers.authorization?.split(" ")[1];
-    const data = await validateToken({ token, origin });
-    res.status(200).json(data);
-  })
-);
-
-router.post(
-  "/esqueci-minha-senha",
-  asyncHandler(async (req, res) => {
-    const origin = await getOrigin();
-    const data = await recoverPassword({ ...req.body, origin });
-    res.status(200).json(data);
-  })
-);
-
-router.post(
-  "/alterar-senha",
-  asyncHandler(async (req, res) => {
-    const origin = await getOrigin();
-    const token = req.headers.authorization?.split(" ")[1];
-    const data = await changePassword({ ...req.body, token, origin });
-    res.status(200).json(data);
-  })
-);
-
-module.exports = router;
+module.exports = authRouter({ getOrigin });


### PR DESCRIPTION
## Summary
- add auth router to core exposing login, token validation, password recovery, and password change
- export router and services from core and depend on express
- replace app auth router with import from core

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_68c19c29be4c832fb6b19f7656adebf7