### PR TITLE
refactor: delegate auth to core module

### DIFF
--- a/central-oon-core-backend/src/auth/service.js
+++ b/central-oon-core-backend/src/auth/service.js
@@ -1,76 +1,151 @@
-const createHttpClient = require('../config/httpClient');
-
-const api = createHttpClient({
-  baseURL: process.env.MEUS_APPS_BACKEND_URL,
-});
+const UsuarioService = require('../../../src/services/usuario');
+const Usuario = require('../../../src/models/Usuario');
+const emailUtils = require('../../../src/utils/emailUtils');
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+const GenericError = require('../errors/GenericError');
 
 /**
- * Realiza o login do usuário utilizando o serviço central de autenticação.
+ * Realiza o login do usuário e retorna token e dados do usuário.
  * @param {Object} params
  * @param {string} params.email
  * @param {string} params.senha
- * @param {string} params.origin
+ * @param {string} [params.origin]
  */
-async function login({ email, senha, origin }) {
-  const { data } = await api.post(
-    '/auth/login',
-    { email, senha },
-    { headers: { origin } },
-  );
-  return data;
+async function login({ email, senha }) {
+  const usuario = await UsuarioService.login({ email, senha });
+
+  return {
+    token: usuario.gerarToken(),
+    usuario: {
+      _id: usuario._id,
+      nome: usuario.nome,
+      tipo: usuario.tipo,
+      idioma: usuario?.configuracoes?.idioma,
+    },
+  };
 }
 
 /**
- * Valida um token JWT junto ao serviço central de autenticação.
+ * Valida um token JWT e retorna o usuário associado.
  * @param {Object} params
  * @param {string} params.token
- * @param {string} params.origin
+ * @param {string} [params.origin]
  */
-async function validateToken({ token, origin }) {
-  const { data } = await api.get('/auth/validar-token', {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      origin,
-    },
-  });
-  return data;
+async function validateToken({ token }) {
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const usuario = await Usuario.findById(decoded.id);
+
+    if (!usuario) {
+      throw new GenericError('Token inválido ou expirado', 401);
+    }
+
+    return { usuario };
+  } catch (error) {
+    throw new GenericError('Token inválido ou expirado', 401);
+  }
 }
 
 /**
- * Solicita a recuperação de senha para o e-mail informado.
+ * Envia email de recuperação de senha para o usuário informado.
  * @param {Object} params
  * @param {string} params.email
- * @param {string} params.origin
+ * @param {string} [params.origin]
  */
-async function recoverPassword({ email, origin }) {
-  const { data } = await api.post(
-    '/auth/esqueci-minha-senha',
-    { email },
-    { headers: { origin } },
-  );
-  return data;
+async function recoverPassword({ email }) {
+  const usuario = await UsuarioService.buscarUsuarioPorEmail({ email });
+  const token = usuario.gerarToken();
+
+  const baseUrl =
+    usuario.tipo === 'prestador'
+      ? process.env.BASE_URL_APP_PUBLISHER
+      : process.env.BASE_URL_CST;
+
+  const path = usuario.tipo === 'prestador' ? '/recover-password' : '/alterar-senha';
+
+  const url = new URL(path, baseUrl);
+  url.searchParams.append('code', token);
+
+  await emailUtils.emailEsqueciMinhaSenha({
+    usuario,
+    url: url.toString(),
+  });
+
+  return { usuario, message: 'Email enviado' };
 }
 
 /**
- * Altera a senha do usuário utilizando token de autorização.
+ * Altera a senha do usuário utilizando token ou código de autorização.
  * @param {Object} params
- * @param {string} params.token
+ * @param {string} [params.token]
+ * @param {string} [params.code]
  * @param {string} params.senhaAtual
  * @param {string} params.novaSenha
- * @param {string} params.origin
+ * @param {string} params.confirmacao
+ * @param {string} [params.origin]
  */
-async function changePassword({ token, senhaAtual, novaSenha, origin }) {
-  const { data } = await api.post(
-    '/auth/alterar-senha',
-    { senhaAtual, novaSenha },
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        origin,
-      },
-    },
-  );
-  return data;
+async function changePassword({ token, senhaAtual, novaSenha, confirmacao, code }) {
+  if (!token && !code) {
+    throw new GenericError('Token inválido ou expirado', 401);
+  }
+
+  if (!novaSenha) {
+    throw new GenericError('Nova senha é um campo obrigatório', 404);
+  }
+
+  if (!confirmacao) {
+    throw new GenericError('Confirmação é um compo obrigatório', 404);
+  }
+
+  if (novaSenha !== confirmacao) {
+    throw new GenericError('A confirmação precisa ser igual a senha.', 400);
+  }
+
+  if (code) {
+    try {
+      const decoded = jwt.verify(code, process.env.JWT_SECRET);
+      const usuario = await Usuario.findById(decoded.id);
+      usuario.senha = novaSenha;
+      await usuario.save();
+      return {
+        token: code,
+        usuario: {
+          _id: usuario._id,
+          nome: usuario.nome,
+          tipo: usuario.tipo,
+        },
+      };
+    } catch (error) {
+      throw new GenericError('Token inválido.', 401);
+    }
+  }
+
+  if (token) {
+    try {
+      const decoded = jwt.verify(token, process.env.JWT_SECRET);
+      const usuario = await Usuario.findById(decoded.id);
+
+      if (!(await bcrypt.compare(senhaAtual, usuario.senha))) {
+        throw new GenericError('Credenciais inválidas', 401);
+      }
+
+      usuario.senha = novaSenha;
+      await usuario.save();
+      return {
+        token,
+        usuario: {
+          _id: usuario._id,
+          nome: usuario.nome,
+          tipo: usuario.tipo,
+        },
+      };
+    } catch (error) {
+      throw new GenericError('Token inválido.', 401);
+    }
+  }
+
+  throw new GenericError('Token inválido.', 404);
 }
 
 module.exports = {
@@ -79,3 +154,4 @@ module.exports = {
   recoverPassword,
   changePassword,
 };
+

--- a/src/controllers/usuario/index.js
+++ b/src/controllers/usuario/index.js
@@ -1,14 +1,9 @@
 const UsuarioService = require("../../services/usuario");
-const Usuario = require("../../models/Usuario");
-const bcrypt = require("bcryptjs");
-const emailUtils = require("../../utils/emailUtils");
-const jwt = require("jsonwebtoken");
 
-const {
-  sendErrorResponse,
-  sendPaginatedResponse,
-  sendResponse,
-} = require("../../utils/helpers");
+const { login, validateToken: validateTokenCore, recoverPassword, changePassword } =
+  require("central-oon-core-backend");
+
+const { sendPaginatedResponse, sendResponse } = require("../../utils/helpers");
 
 const criarUsuario = async (req, res) => {
   const usuario = await UsuarioService.criar({ usuario: req.body });
@@ -35,151 +30,25 @@ const excluirUsuario = async (req, res) => {
 };
 
 const loginUsuario = async (req, res) => {
-  const { email, senha } = req.body;
-  const usuario = await UsuarioService.login({ email, senha });
-
-  sendResponse({
-    res,
-    statusCode: 200,
-    token: usuario.gerarToken(),
-    usuario: {
-      _id: usuario._id,
-      nome: usuario.nome,
-      tipo: usuario.tipo,
-      idioma: usuario?.configuracoes?.idioma,
-    },
-  });
+  const data = await login(req.body);
+  sendResponse({ res, statusCode: 200, ...data });
 };
 
 const validarToken = async (req, res) => {
-  // Se passou pelo middleware, `req.usuario` já está preenchido
-  sendResponse({ res, statusCode: 200, usuario: req.usuario });
+  const token = req.headers.authorization?.split(" ")[1];
+  const data = await validateTokenCore({ token });
+  sendResponse({ res, statusCode: 200, ...data });
 };
 
 const esqueciMinhaSenha = async (req, res) => {
-  const { email } = req.body;
-
-  const usuario = await UsuarioService.buscarUsuarioPorEmail({ email });
-  const token = usuario.gerarToken();
-
-  const baseUrl =
-    usuario.tipo === "prestador"
-      ? process.env.BASE_URL_APP_PUBLISHER
-      : process.env.BASE_URL_CST;
-
-  const path =
-    usuario.tipo === "prestador" ? "/recover-password" : "/alterar-senha";
-
-  const url = new URL(path, baseUrl);
-  url.searchParams.append("code", token);
-
-  await emailUtils.emailEsqueciMinhaSenha({
-    usuario,
-    url: url.toString(),
-  });
-
-  sendResponse({ res, statusCode: 200, usuario, message: "Email enviado" });
+  const data = await recoverPassword(req.body);
+  sendResponse({ res, statusCode: 200, ...data });
 };
 
 const alterarSenha = async (req, res) => {
   const token = req.headers.authorization?.split(" ")[1];
-  const { senhaAtual, novaSenha, confirmacao, code } = req.body;
-
-  if (!token && !code) {
-    return sendErrorResponse({
-      res,
-      statusCode: 401,
-      message: "Token inválido ou expirado",
-    });
-  }
-
-  if (!novaSenha) {
-    return sendErrorResponse({
-      res,
-      statusCode: 404,
-      message: "Nova senha é um campo obrigatório",
-    });
-  }
-
-  if (!confirmacao) {
-    return sendErrorResponse({
-      res,
-      statusCode: 404,
-      message: "Confirmação é um compo obrigatório",
-    });
-  }
-
-  if (novaSenha !== confirmacao) {
-    return sendErrorResponse({
-      res,
-      statusCode: 400,
-      message: "A confirmação precisa ser igual a senha.",
-    });
-  }
-
-  if (code) {
-    try {
-      const decoded = jwt.verify(code, process.env.JWT_SECRET);
-      const usuario = await Usuario.findById(decoded.id);
-      usuario.senha = novaSenha;
-      await usuario.save();
-      return sendResponse({
-        res,
-        statusCode: 200,
-        token: code,
-        usuario: {
-          _id: usuario._id,
-          nome: usuario.nome,
-          tipo: usuario.tipo,
-        },
-      });
-    } catch (error) {
-      return sendErrorResponse({
-        res,
-        statusCode: 401,
-        message: "Token inválido.",
-      });
-    }
-  }
-
-  if (token) {
-    try {
-      const decoded = jwt.verify(token, process.env.JWT_SECRET);
-      const usuario = await Usuario.findById(decoded.id);
-
-      if (!(await bcrypt.compare(senhaAtual, usuario.senha)))
-        return sendErrorResponse({
-          res,
-          statusCode: 401,
-          message: "Credenciais inválidas",
-        });
-
-      usuario.senha = novaSenha;
-      await usuario.save();
-      return sendResponse({
-        res,
-        statusCode: 200,
-        token,
-        usuario: {
-          _id: usuario._id,
-          nome: usuario.nome,
-          tipo: usuario.tipo,
-        },
-      });
-    } catch (error) {
-      return sendErrorResponse({
-        res,
-        statusCode: 401,
-        message: "Token inválido.",
-      });
-    }
-  }
-
-  return sendErrorResponse({
-    res,
-    statusCode: 404,
-    message: "Token inválido.",
-  });
+  const data = await changePassword({ ...req.body, token });
+  sendResponse({ res, statusCode: 200, ...data });
 };
 
 const listarUsuarios = async (req, res) => {


### PR DESCRIPTION
## Summary
- move authentication logic into core auth service
- delegate usuario controller auth endpoints to core functions

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1a0c01c40832f83fefb3a1d6d8ca8