### PR TITLE
fix: handle token validation errors in middleware

### DIFF
--- a/src/middlewares/errorMiddleware.js
+++ b/src/middlewares/errorMiddleware.js
@@ -1,5 +1,6 @@
 const multer = require('multer');
 const GenericError = require('../services/errors/generic');
+const CoreGenericError = require('central-oon-core-backend/src/errors/GenericError');
 const { sendErrorResponse } = require('../utils/helpers');
 
 const errorMiddleware = (error, _, res, next) => {
@@ -23,7 +24,20 @@ const errorMiddleware = (error, _, res, next) => {
     });
   }
 
-  if (error instanceof GenericError) {
+  if (['JsonWebTokenError', 'TokenExpiredError', 'NotBeforeError'].includes(error.name)) {
+    return sendErrorResponse({
+      res,
+      statusCode: 401,
+      error: error.message,
+      message: 'Token inválido ou expirado.',
+    });
+  }
+
+  if (
+    error instanceof GenericError ||
+    error instanceof CoreGenericError ||
+    typeof error.statusCode === 'number'
+  ) {
     return sendErrorResponse({
       res,
       statusCode: error.statusCode,


### PR DESCRIPTION
## Summary
- handle token validation errors with 401 status
- support core GenericError and statusCode-based errors in middleware

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a54fb8d0832fafd46619ee5bf11f