### PR TITLE
refactor: use centralized utils

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -14,7 +14,9 @@ const {
 } = require("central-oon-core-backend");
 const Sistema = require("./models/Sistema");
 const getOrigin = async () => (await Sistema.findOne())?.appKey;
-const { asyncHandler } = require("./utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 const IntegracaoController = require("./controllers/integracao");
 const MoedaController = require("./controllers/moeda");
 

--- a/src/controllers/arquivo/index.js
+++ b/src/controllers/arquivo/index.js
@@ -1,4 +1,6 @@
-const { sendResponse } = require("../../utils/helpers");
+const {
+  helpers: { sendResponse },
+} = require("central-oon-core-backend");
 const ArquivoService = require("../../services/arquivo");
 
 const obterArquivoPorId = async (req, res) => {

--- a/src/controllers/assistente/index.js
+++ b/src/controllers/assistente/index.js
@@ -1,4 +1,6 @@
-const { sendResponse, sendPaginatedResponse } = require("../../utils/helpers");
+const {
+  helpers: { sendResponse, sendPaginatedResponse },
+} = require("central-oon-core-backend");
 const AssistenteService = require("../../services/assistente");
 
 const criarAssistente = async (req, res) => {

--- a/src/controllers/contaPagar/omie/webhook.js
+++ b/src/controllers/contaPagar/omie/webhook.js
@@ -1,4 +1,4 @@
-const Helpers = require("../../../utils/helpers");
+const { helpers: Helpers } = require("central-oon-core-backend");
 const BaseOmie = require("../../../models/BaseOmie");
 const ContaPagarSync = require("../../../services/contaPagar/omie");
 

--- a/src/controllers/dashboard/index.js
+++ b/src/controllers/dashboard/index.js
@@ -1,4 +1,4 @@
-const Helpers = require("../../utils/helpers");
+const { helpers: Helpers } = require("central-oon-core-backend");
 const ServicoService = require("../../services/servico");
 const ServicoTomadoTicketService = require("../../services/servicoTomadoTicket");
 const IntegracaoService = require("../../services/integracao");

--- a/src/controllers/documentoCadastral/index.js
+++ b/src/controllers/documentoCadastral/index.js
@@ -6,7 +6,14 @@
 
 const DocumentoCadastralService = require("../../services/documentoCadastral");
 const DocumentoCadastralExcel = require("../../services/documentoCadastral/excel");
-const { arrayToExcelBuffer } = require("../../utils/excel");
+const {
+  excel: { arrayToExcelBuffer },
+  helpers: {
+    sendPaginatedResponse,
+    sendResponse,
+    // sendErrorResponse,
+  },
+} = require("central-oon-core-backend");
 const ImportacaoService = require("../../services/importacao");
 
 // const DocumentoCadastral = require("../../models/DocumentoCadastral");
@@ -21,11 +28,6 @@ const ImportacaoService = require("../../services/importacao");
 //   ORIGENS,
 // } = require("../../constants/controleAlteracao");
 
-const {
-  sendPaginatedResponse,
-  sendResponse,
-  // sendErrorResponse,
-} = require("../../utils/helpers");
 
 const criar = async (req, res) => {
   const documentoCadastral = await DocumentoCadastralService.criar({

--- a/src/controllers/documentoFiscal/index.js
+++ b/src/controllers/documentoFiscal/index.js
@@ -9,7 +9,14 @@ const DocumentoFiscalService = require("../../services/documentoFiscal");
 const EtapaService = require("../../services/etapa");
 
 const DocumentoFiscalExcel = require("../../services/documentoFiscal/excel");
-const { arrayToExcelBuffer } = require("../../utils/excel");
+const {
+  excel: { arrayToExcelBuffer },
+  helpers: {
+    sendPaginatedResponse,
+    sendResponse,
+    // sendErrorResponse,
+  },
+} = require("central-oon-core-backend");
 const ImportacaoService = require("../../services/importacao");
 
 // const DocumentoFidocumentoFiscal = require("../../models/DocumentoFidocumentoFiscal");
@@ -24,11 +31,6 @@ const ImportacaoService = require("../../services/importacao");
 //   ORIGENS,
 // } = require("../../constants/controleAlteracao");
 
-const {
-  sendPaginatedResponse,
-  sendResponse,
-  // sendErrorResponse,
-} = require("../../utils/helpers");
 const ServicoTomadoTicket = require("../../models/ServicoTomadoTicket");
 
 const criar = async (req, res) => {

--- a/src/controllers/etapa/index.js
+++ b/src/controllers/etapa/index.js
@@ -1,5 +1,7 @@
 const EtapaService = require("../../services/etapa");
-const { sendResponse, sendPaginatedResponse } = require("../../utils/helpers");
+const {
+  helpers: { sendResponse, sendPaginatedResponse },
+} = require("central-oon-core-backend");
 
 const criarEtapa = async (req, res) => {
   const etapa = await EtapaService.criar({ etapa: req.body });

--- a/src/controllers/importacao/index.js
+++ b/src/controllers/importacao/index.js
@@ -1,5 +1,7 @@
 const ImportacaoService = require("../../services/importacao");
-const { sendPaginatedResponse } = require("../../utils/helpers");
+const {
+  helpers: { sendPaginatedResponse },
+} = require("central-oon-core-backend");
 
 const listar = async (req, res) => {
   const { pageIndex = 0, pageSize = 10, tipo } = req.query;

--- a/src/controllers/integracao/index.js
+++ b/src/controllers/integracao/index.js
@@ -1,5 +1,5 @@
 const IntegracaoService = require("../../services/integracao");
-const Helpers = require("../../utils/helpers");
+const { helpers: Helpers } = require("central-oon-core-backend");
 const PessoaSync = require("../../services/pessoa/omie");
 const ContaPagarSync = require("../../services/contaPagar/omie");
 const ArquivosSync = require("../../services/arquivo/omie");

--- a/src/controllers/lista/index.js
+++ b/src/controllers/lista/index.js
@@ -1,4 +1,6 @@
-const { sendResponse } = require("../../utils/helpers");
+const {
+  helpers: { sendResponse },
+} = require("central-oon-core-backend");
 const { registrarAcao } = require("central-oon-core-backend");
 const {
   ENTIDADES,

--- a/src/controllers/listaOmieController/index.js
+++ b/src/controllers/listaOmieController/index.js
@@ -1,5 +1,7 @@
 const ListaOmieService = require("../../services/listaOmie");
-const { sendResponse } = require("../../utils/helpers");
+const {
+  helpers: { sendResponse },
+} = require("central-oon-core-backend");
 
 const syncOmie = async (req, res) => {
   const lista = await ListaOmieService.syncWithOmie({ id: req.params.id });

--- a/src/controllers/moeda/index.js
+++ b/src/controllers/moeda/index.js
@@ -1,5 +1,5 @@
 const MoedaService = require("../../services/moeda");
-const Helpers = require("../../utils/helpers");
+const { helpers: Helpers } = require("central-oon-core-backend");
 
 // const criar = async (req, res) => {
 //   const pessoa = await MoedaService.criar({ pessoa: req.body });

--- a/src/controllers/pessoa/index.js
+++ b/src/controllers/pessoa/index.js
@@ -1,8 +1,10 @@
 const PessoaService = require("../../services/pessoa");
 const PessoaExcel = require("../../services/pessoa/excel");
 const ImportacaoService = require("../../services/importacao");
-const { sendPaginatedResponse, sendResponse } = require("../../utils/helpers");
-const { arrayToExcelBuffer, excelToJson } = require("../../utils/excel");
+const {
+  helpers: { sendPaginatedResponse, sendResponse },
+  excel: { arrayToExcelBuffer, excelToJson },
+} = require("central-oon-core-backend");
 
 const criar = async (req, res) => {
   const pessoa = await PessoaService.criar({ pessoa: req.body });

--- a/src/controllers/pessoa/omie/webhook.js
+++ b/src/controllers/pessoa/omie/webhook.js
@@ -1,4 +1,4 @@
-const Helpers = require("../../../utils/helpers");
+const { helpers: Helpers } = require("central-oon-core-backend");
 const PessoaSync = require("../../../services/pessoa/omie");
 const BaseOmie = require("../../../models/BaseOmie");
 

--- a/src/controllers/planejamento/index.js
+++ b/src/controllers/planejamento/index.js
@@ -1,5 +1,7 @@
 const PlanejamentoService = require("../../services/planejamento");
-const { sendPaginatedResponse, sendResponse } = require("../../utils/helpers");
+const {
+  helpers: { sendPaginatedResponse, sendResponse },
+} = require("central-oon-core-backend");
 const ServicoService = require("../../services/servico");
 
 const listar = async (req, res) => {

--- a/src/controllers/servico/index.js
+++ b/src/controllers/servico/index.js
@@ -1,7 +1,9 @@
-const { sendPaginatedResponse, sendResponse } = require("../../utils/helpers");
+const {
+  helpers: { sendPaginatedResponse, sendResponse },
+  excel: { arrayToExcelBuffer },
+} = require("central-oon-core-backend");
 const ServicoService = require("../../services/servico");
 const ServicoExcel = require("../../services/servico/excel");
-const { arrayToExcelBuffer } = require("../../utils/excel");
 const ImportacaoService = require("../../services/importacao");
 
 const criar = async (req, res) => {

--- a/src/controllers/servicoTomadoTicket/index.js
+++ b/src/controllers/servicoTomadoTicket/index.js
@@ -1,8 +1,10 @@
 const {
-  sendResponse,
-  sendErrorResponse,
-  sendPaginatedResponse,
-} = require("../../utils/helpers");
+  helpers: {
+    sendResponse,
+    sendErrorResponse,
+    sendPaginatedResponse,
+  },
+} = require("central-oon-core-backend");
 
 const ServicoTomadoTicketService = require("../../services/servicoTomadoTicket");
 const ServicoService = require("../../services/servico");

--- a/src/controllers/sistema/index.js
+++ b/src/controllers/sistema/index.js
@@ -1,6 +1,5 @@
 const Sistema = require("../../models/Sistema");
 const { emailTeste } = require("../../utils/emailUtils");
-const Helpers = require("../../utils/helpers");
 
 listarSistemaConfig = async (req, res) => {
   const sistema = await Sistema.findOne();

--- a/src/controllers/usuario/index.js
+++ b/src/controllers/usuario/index.js
@@ -5,10 +5,8 @@ const emailUtils = require("../../utils/emailUtils");
 const jwt = require("jsonwebtoken");
 
 const {
-  sendErrorResponse,
-  sendPaginatedResponse,
-  sendResponse,
-} = require("../../utils/helpers");
+  helpers: { sendErrorResponse, sendPaginatedResponse, sendResponse },
+} = require("central-oon-core-backend");
 
 const criarUsuario = async (req, res) => {
   const usuario = await UsuarioService.criar({ usuario: req.body });

--- a/src/routers/arquivoRouter.js
+++ b/src/routers/arquivoRouter.js
@@ -1,6 +1,8 @@
 const express = require("express");
 const ArquivoController = require("../controllers/arquivo");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 const router = express.Router();
 
 router.get("/:id", asyncHandler(ArquivoController.obterArquivoPorId));

--- a/src/routers/assistenteRouter.js
+++ b/src/routers/assistenteRouter.js
@@ -3,7 +3,9 @@ const router = express.Router();
 const AssistenteController = require("../controllers/assistente");
 const { registrarAcaoMiddleware } = require("central-oon-core-backend");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 
 router.post(
   "/",

--- a/src/routers/authRouter.js
+++ b/src/routers/authRouter.js
@@ -2,7 +2,9 @@ const express = require("express");
 const router = express.Router();
 const UsuarioController = require("../controllers/usuario");
 const { authMiddleware } = require("central-oon-core-backend");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 const Sistema = require("../models/Sistema");
 const getOrigin = async () => (await Sistema.findOne())?.appKey;
 

--- a/src/routers/dashboardRouter.js
+++ b/src/routers/dashboardRouter.js
@@ -1,5 +1,7 @@
 const { Router } = require("express");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 const DashboardController = require("../controllers/dashboard");
 const router = Router();
 

--- a/src/routers/documentoCadastralRouter.js
+++ b/src/routers/documentoCadastralRouter.js
@@ -6,7 +6,9 @@ const router = express.Router();
 const { uploadExcel, uploadPDF } = require("central-oon-core-backend");
 const { registrarAcaoMiddleware } = require("central-oon-core-backend");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 
 router.get("/", asyncHandler(DocumentoCadastralController.listar));
 router.get("/exportar", asyncHandler(DocumentoCadastralController.exportar));

--- a/src/routers/documentoFiscalRouter.js
+++ b/src/routers/documentoFiscalRouter.js
@@ -6,7 +6,9 @@ const router = express.Router();
 const { uploadExcel, uploadPDF } = require("central-oon-core-backend");
 const { registrarAcaoMiddleware } = require("central-oon-core-backend");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 
 router.get("/", asyncHandler(DocumentoFiscalController.listar));
 router.get("/exportar", asyncHandler(DocumentoFiscalController.exportar));

--- a/src/routers/etapaRouter.js
+++ b/src/routers/etapaRouter.js
@@ -3,7 +3,9 @@ const router = express.Router();
 const EtapaController = require("../controllers/etapa");
 const { registrarAcaoMiddleware } = require("central-oon-core-backend");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 
 router.post(
   "/",

--- a/src/routers/importacaoRouter.js
+++ b/src/routers/importacaoRouter.js
@@ -1,6 +1,8 @@
 const express = require("express");
 const ImportacaoController = require("../controllers/importacao");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 
 const router = express.Router();
 router.get("/", asyncHandler(ImportacaoController.listar));

--- a/src/routers/integracaoRouter.js
+++ b/src/routers/integracaoRouter.js
@@ -1,6 +1,8 @@
 const express = require("express");
 const IntegracaoController = require("../controllers/integracao");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 const { registrarAcaoMiddleware } = require("central-oon-core-backend");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
 

--- a/src/routers/listaRouter.js
+++ b/src/routers/listaRouter.js
@@ -1,7 +1,9 @@
 const express = require("express");
 const router = express.Router();
 const ListaController = require("../controllers/lista");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 
 router.post("/", asyncHandler(ListaController.createLista));
 router.get("/", asyncHandler(ListaController.getListas));

--- a/src/routers/listasOmieRouter.js
+++ b/src/routers/listasOmieRouter.js
@@ -4,7 +4,9 @@ const { ListaOmieController } = require("../controllers/listaOmieController");
 
 const { registrarAcaoMiddleware } = require("central-oon-core-backend");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 
 router.post("/", asyncHandler(ListaOmieController.create));
 router.get("/", asyncHandler(ListaOmieController.listAll));

--- a/src/routers/moedaRouter.js
+++ b/src/routers/moedaRouter.js
@@ -2,7 +2,9 @@ const express = require("express");
 const MoedaController = require("../controllers/moeda");
 const { registrarAcaoMiddleware } = require("central-oon-core-backend");
 const router = express.Router();
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
 const { uploadExcel } = require("central-oon-core-backend");
 

--- a/src/routers/pessoaRouter.js
+++ b/src/routers/pessoaRouter.js
@@ -2,7 +2,9 @@ const express = require("express");
 const PessoaController = require("../controllers/pessoa");
 const { registrarAcaoMiddleware } = require("central-oon-core-backend");
 const router = express.Router();
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
 const { uploadExcel } = require("central-oon-core-backend");
 

--- a/src/routers/planejamentoRouter.js
+++ b/src/routers/planejamentoRouter.js
@@ -1,6 +1,8 @@
 const express = require("express");
 const PlanejamentoController = require("../controllers/planejamento");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 const router = express.Router();
 
 router.get("/listar-servicos", asyncHandler(PlanejamentoController.listar));

--- a/src/routers/seedRouter.js
+++ b/src/routers/seedRouter.js
@@ -23,10 +23,8 @@ const moedas = require("../seeds/moedas.json");
 const integracoes = require("../seeds/integracao.json");
 
 const {
-  sendErrorResponse,
-  sendResponse,
-  asyncHandler,
-} = require("../utils/helpers");
+  helpers: { sendErrorResponse, sendResponse, asyncHandler },
+} = require("central-oon-core-backend");
 
 const seed = async (req, res) => {
   const { baseOmie, appKey, openIaKey } = req.body;

--- a/src/routers/servicoRouter.js
+++ b/src/routers/servicoRouter.js
@@ -2,7 +2,9 @@ const express = require("express");
 const ServicoController = require("../controllers/servico");
 const { registrarAcaoMiddleware } = require("central-oon-core-backend");
 const router = express.Router();
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
 const { uploadExcel } = require("central-oon-core-backend");
 

--- a/src/routers/servicoTomadoTicketRouter.js
+++ b/src/routers/servicoTomadoTicketRouter.js
@@ -4,7 +4,9 @@ const ServicoTomadoTicketController = require("../controllers/servicoTomadoTicke
 const multer = require("multer");
 const { registrarAcaoMiddleware } = require("central-oon-core-backend");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 const storage = multer.memoryStorage({});
 
 const fileFilter = (req, file, cb) => {

--- a/src/routers/sistemaRouter.js
+++ b/src/routers/sistemaRouter.js
@@ -1,6 +1,8 @@
 const express = require("express");
 const SistemaService = require("../controllers/sistema");
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 const router = express.Router();
 
 router.get("/", asyncHandler(SistemaService.listarSistemaConfig));

--- a/src/routers/tipoAcessoRouter.js
+++ b/src/routers/tipoAcessoRouter.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = express.Router();
-const Helpers = require("../utils/helpers");
+const { helpers: Helpers } = require("central-oon-core-backend");
 
 router.get(
   "/",

--- a/src/routers/usuarioRouter.js
+++ b/src/routers/usuarioRouter.js
@@ -3,7 +3,9 @@ const UsuarioController = require("../controllers/usuario");
 const { registrarAcaoMiddleware } = require("central-oon-core-backend");
 const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
 const router = express.Router();
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 
 router.get("/", asyncHandler(UsuarioController.listarUsuarios));
 

--- a/src/routers/webhookRouter.js
+++ b/src/routers/webhookRouter.js
@@ -3,7 +3,9 @@ const express = require("express");
 const PessoaWebhook = require("../controllers/pessoa/omie/webhook");
 const ContaPagarWebhook = require("../controllers/contaPagar/omie/webhook");
 
-const { asyncHandler } = require("../utils/helpers");
+const {
+  helpers: { asyncHandler },
+} = require("central-oon-core-backend");
 const router = express.Router();
 
 router.post("/pessoa", asyncHandler(PessoaWebhook.SyncPessoa));

--- a/src/services/arquivo/omie/central-omie/handler.js
+++ b/src/services/arquivo/omie/central-omie/handler.js
@@ -2,7 +2,9 @@ const AnexoService = require("../../../omie/anexosService.js");
 const ContaPagar = require("../../../../models/ContaPagar.js");
 const BaseOmie = require("../../../../models/BaseOmie.js");
 const { processarIntegracao } = require("../../../queue/defaultHandler.js");
-const { compactFile } = require("../../../../utils/fileHandler.js");
+const {
+  fileHandler: { compactFile },
+} = require("central-oon-core-backend");
 const Integracao = require("../../../../models/Integracao.js");
 
 const handler = async (integracao) => {

--- a/src/services/assistente/index.js
+++ b/src/services/assistente/index.js
@@ -1,6 +1,8 @@
 const Assistente = require("../../models/Assistente");
-const FiltersUtils = require("../../utils/pagination/filter");
-const PaginationUtils = require("../../utils/pagination");
+const {
+  filters: FiltersUtils,
+  pagination: PaginationUtils,
+} = require("central-oon-core-backend");
 const AssistenteNaoEncontradoError = require("../errors/assistente/assistenteNaoEncontrado");
 
 const criar = async ({ assistente }) => {

--- a/src/services/documentoCadastral/excel/index.js
+++ b/src/services/documentoCadastral/excel/index.js
@@ -1,5 +1,7 @@
-const { excelToJson } = require("../../../utils/excel.js");
-const { registrarAcao } = require("central-oon-core-backend");
+const {
+  excel: { excelToJson },
+  registrarAcao,
+} = require("central-oon-core-backend");
 const {
   ACOES,
   ENTIDADES,

--- a/src/services/documentoCadastral/index.js
+++ b/src/services/documentoCadastral/index.js
@@ -1,6 +1,8 @@
 const DocumentoCadastral = require("../../models/DocumentoCadastral");
-const FiltersUtils = require("../../utils/pagination/filter");
-const PaginationUtils = require("../../utils/pagination");
+const {
+  filters: FiltersUtils,
+  pagination: PaginationUtils,
+} = require("central-oon-core-backend");
 const Arquivo = require("../../models/Arquivo");
 const { criarNomePersonalizado } = require("../../utils/formatters");
 const ArquivoNaoEncontradoError = require("../errors/arquivo/arquivoNaoEncontradoError");

--- a/src/services/documentoFiscal/excel/index.js
+++ b/src/services/documentoFiscal/excel/index.js
@@ -1,5 +1,7 @@
-const { excelToJson } = require("../../../utils/excel.js");
-const { registrarAcao } = require("central-oon-core-backend");
+const {
+  excel: { excelToJson },
+  registrarAcao,
+} = require("central-oon-core-backend");
 const {
   ACOES,
   ENTIDADES,

--- a/src/services/documentoFiscal/index.js
+++ b/src/services/documentoFiscal/index.js
@@ -1,6 +1,8 @@
 const DocumentoFiscal = require("../../models/DocumentoFiscal");
-const FiltersUtils = require("../../utils/pagination/filter");
-const PaginationUtils = require("../../utils/pagination");
+const {
+  filters: FiltersUtils,
+  pagination: PaginationUtils,
+} = require("central-oon-core-backend");
 const Arquivo = require("../../models/Arquivo");
 const { criarNomePersonalizado } = require("../../utils/formatters");
 const ArquivoNaoEncontradoError = require("../errors/arquivo/arquivoNaoEncontradoError");

--- a/src/services/etapa/index.js
+++ b/src/services/etapa/index.js
@@ -1,7 +1,9 @@
 const Etapa = require("../../models/Etapa");
 const EtapaNaoEncontradaError = require("../errors/etapa/etapaNaoEncontradaError");
-const FiltersUtils = require("../../utils/pagination/filter");
-const PaginationUtils = require("../../utils/pagination");
+const {
+  filters: FiltersUtils,
+  pagination: PaginationUtils,
+} = require("central-oon-core-backend");
 
 const criar = async ({ etapa }) => {
   const etapaNova = new Etapa(etapa);

--- a/src/services/importacao/index.js
+++ b/src/services/importacao/index.js
@@ -1,5 +1,7 @@
 const Importacao = require("../../models/Importacao");
-const PaginationUtils = require("../../utils/pagination");
+const {
+  pagination: PaginationUtils,
+} = require("central-oon-core-backend");
 const GenericError = require("../errors/generic");
 
 const criar = async ({ tipo, arquivo }) => {

--- a/src/services/integracao/index.js
+++ b/src/services/integracao/index.js
@@ -1,6 +1,8 @@
 const Integracao = require("../../models/Integracao");
-const FiltersUtils = require("../../utils/pagination/filter");
-const PaginationUtils = require("../../utils/pagination");
+const {
+  filters: FiltersUtils,
+  pagination: PaginationUtils,
+} = require("central-oon-core-backend");
 const IntegracaoNaoEncontradoError = require("../errors/integracao/integracaoNaoEncontrado");
 const ServicoTomadoTicket = require("../../models/ServicoTomadoTicket");
 const ContaPagar = require("../../models/ContaPagar");

--- a/src/services/moeda/index.js
+++ b/src/services/moeda/index.js
@@ -1,6 +1,8 @@
 const Moeda = require("../../models/Moeda");
-const FiltersUtils = require("../../utils/pagination/filter");
-const PaginationUtils = require("../../utils/pagination");
+const {
+  filters: FiltersUtils,
+  pagination: PaginationUtils,
+} = require("central-oon-core-backend");
 const CotacaoService = require("./bacen");
 
 const listarComPaginacao = async ({

--- a/src/services/omie/anexosService.js
+++ b/src/services/omie/anexosService.js
@@ -1,5 +1,7 @@
-const { compactFile } = require("../../utils/fileHandler");
-const { createHttpClient } = require("central-oon-core-backend");
+const {
+  fileHandler: { compactFile },
+  createHttpClient,
+} = require("central-oon-core-backend");
 
 const apiOmie = createHttpClient({ baseURL: process.env.API_OMIE });
 

--- a/src/services/pessoa/excel/index.js
+++ b/src/services/pessoa/excel/index.js
@@ -1,5 +1,7 @@
-const { excelToJson } = require("../../../utils/excel.js");
-const { registrarAcao } = require("central-oon-core-backend");
+const {
+  excel: { excelToJson },
+  registrarAcao,
+} = require("central-oon-core-backend");
 const {
   ACOES,
   ENTIDADES,

--- a/src/services/pessoa/index.js
+++ b/src/services/pessoa/index.js
@@ -1,7 +1,9 @@
 const PessoaBusiness = require("./business");
 const Pessoa = require("../../models/Pessoa");
-const FiltersUtils = require("../../utils/pagination/filter");
-const PaginationUtils = require("../../utils/pagination");
+const {
+  filters: FiltersUtils,
+  pagination: PaginationUtils,
+} = require("central-oon-core-backend");
 const PessoaNaoEncontradaError = require("../errors/pessoa/pessoaNaoEncontradaError");
 const { LISTA_PAISES_OMIE } = require("../../constants/omie/paises");
 

--- a/src/services/planejamento/index.js
+++ b/src/services/planejamento/index.js
@@ -1,6 +1,8 @@
 const Servico = require("../../models/Servico");
-const FiltersUtils = require("../../utils/pagination/filter");
-const PaginationUtils = require("../../utils/pagination");
+const {
+  filters: FiltersUtils,
+  pagination: PaginationUtils,
+} = require("central-oon-core-backend");
 const { registrarAcao } = require("central-oon-core-backend");
 const ServicoTomadoTicket = require("../../models/ServicoTomadoTicket");
 const {

--- a/src/services/queue/defaultHandler.js
+++ b/src/services/queue/defaultHandler.js
@@ -1,5 +1,5 @@
 const { ETAPAS_DEFAULT } = require("../../constants/integracao");
-const Helpers = require("../../utils/helpers");
+const { helpers: Helpers } = require("central-oon-core-backend");
 
 const processarIntegracao = async ({
   integracao,

--- a/src/services/servico/excel/index.js
+++ b/src/services/servico/excel/index.js
@@ -1,5 +1,7 @@
-const { excelToJson } = require("../../../utils/excel.js");
-const { registrarAcao } = require("central-oon-core-backend");
+const {
+  excel: { excelToJson },
+  registrarAcao,
+} = require("central-oon-core-backend");
 const {
   ACOES,
   ENTIDADES,

--- a/src/services/servico/index.js
+++ b/src/services/servico/index.js
@@ -1,6 +1,8 @@
 const Servico = require("../../models/Servico");
-const FiltersUtils = require("../../utils/pagination/filter");
-const PaginationUtils = require("../../utils/pagination");
+const {
+  filters: FiltersUtils,
+  pagination: PaginationUtils,
+} = require("central-oon-core-backend");
 const PessoaService = require("../pessoa");
 const MoedaService = require("../moeda/bacen");
 

--- a/src/services/servicoTomadoTicket/index.js
+++ b/src/services/servicoTomadoTicket/index.js
@@ -1,7 +1,9 @@
 const ServicoTomadoTicket = require("../../models/ServicoTomadoTicket");
 const Servico = require("../../models/Servico");
-const FiltersUtils = require("../../utils/pagination/filter");
-const PaginationUtils = require("../../utils/pagination");
+const {
+  filters: FiltersUtils,
+  pagination: PaginationUtils,
+} = require("central-oon-core-backend");
 const { aprovar } = require("./aprovar");
 const { reprovar } = require("./reprovar");
 const TicketNaoEncontradoError = require("../errors/ticket/ticketNaoEncontrado");

--- a/src/services/usuario/index.js
+++ b/src/services/usuario/index.js
@@ -2,8 +2,10 @@ const Usuario = require("../../models/Usuario");
 const CredenciaisInvalidasError = require("../errors/usuario/credenciaisInvalidas");
 const UsuarioNaoEncontradoError = require("../errors/usuario/usuarioNaoEncontrado");
 const bcrypt = require("bcryptjs");
-const FiltersUtils = require("../../utils/pagination/filter");
-const PaginationUtils = require("../../utils/pagination");
+const {
+  filters: FiltersUtils,
+  pagination: PaginationUtils,
+} = require("central-oon-core-backend");
 
 const criar = async ({ usuario }) => {
   const novoUsuario = new Usuario(usuario);

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -1,1 +1,0 @@
-module.exports = require("central-oon-core-backend").excel;

--- a/src/utils/fileHandler.js
+++ b/src/utils/fileHandler.js
@@ -1,1 +1,0 @@
-module.exports = require("central-oon-core-backend").fileHandler;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,1 +1,0 @@
-module.exports = require("central-oon-core-backend").helpers;

--- a/src/utils/pagination/filter.js
+++ b/src/utils/pagination/filter.js
@@ -1,1 +1,0 @@
-module.exports = require("central-oon-core-backend").filters;

--- a/src/utils/pagination/index.js
+++ b/src/utils/pagination/index.js
@@ -1,1 +1,0 @@
-module.exports = require("central-oon-core-backend").pagination;


### PR DESCRIPTION
## Summary
- remove local utils wrappers and pagination helpers
- import excel, helpers, fileHandler and pagination from central-oon-core-backend

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check src/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1b4e2b714832fbe88e0772fde87b3