### PR TITLE
fix: make convite template synchronous

### DIFF
--- a/src/constants/template.js
+++ b/src/constants/template.js
@@ -1,4 +1,4 @@
-exports.conviteTemplate = async ({ url }) => {
+exports.conviteTemplate = ({ url }) => {
   return `<!DOCTYPE html>
 <html lang="pt-BR">
 <head>

--- a/src/utils/emailUtils.js
+++ b/src/utils/emailUtils.js
@@ -128,7 +128,7 @@ const emailLinkCadastroUsuarioPrestador = async ({ email, nome, url }) => {
 
     const assunto = "Acesso Liberado";
 
-    const corpo = await conviteTemplate({ url });
+    const corpo = conviteTemplate({ url });
 
     return await enviarEmail(emailTo, assunto, corpo);
   } catch (error) {


### PR DESCRIPTION
## Summary
- make convite template synchronous
- call conviteTemplate without awaiting

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1e00766f4832fabc7f64dd72b1d36