### PR TITLE
feat: add automatic router registration

### DIFF
--- a/central-oon-core-backend/src/boot/createApp.js
+++ b/central-oon-core-backend/src/boot/createApp.js
@@ -5,7 +5,14 @@ const morgan = require('morgan');
 const dotenv = require('dotenv');
 
 // Loads environment variables and returns a configured Express application
-function createApp({ middlewares = [], routers = [] } = {}) {
+//
+// @param {Object} [options]
+// @param {Array} [options.middlewares] - Additional middlewares to load.
+// @param {Array<{path: string, router: import('express').Router}>} [options.routers] - Routers to register.
+// @param {boolean} [options.autoRouters=true] - When true, core routers
+// (controleAlteracao, importacao, lista and etapa) are automatically
+// registered on their default paths.
+function createApp({ middlewares = [], routers = [], autoRouters = true } = {}) {
   dotenv.config();
 
   const app = express();
@@ -20,6 +27,20 @@ function createApp({ middlewares = [], routers = [] } = {}) {
   }
 
   middlewares.forEach((mw) => app.use(mw));
+
+  if (autoRouters) {
+    const controleAlteracaoRouter = require('../routers/controleAlteracaoRouter');
+    const importacaoRouter = require('../routers/importacaoRouter');
+    const listaRouter = require('../routers/listaRouter');
+    const etapaRouter = require('../routers/etapaRouter');
+
+    routers.push(
+      { path: '/registros', router: controleAlteracaoRouter },
+      { path: '/importacoes', router: importacaoRouter },
+      { path: '/listas', router: listaRouter },
+      { path: '/etapas', router: etapaRouter }
+    );
+  }
 
   routers.forEach(({ path = '/', router }) => {
     app.use(path, router);

--- a/src/app.js
+++ b/src/app.js
@@ -10,10 +10,6 @@ const {
   GenericError,
   logMiddleware,
   authMiddleware,
-  controleAlteracaoRouter,
-  importacaoRouter,
-  listaRouter,
-  etapaRouter,
 } = require("central-oon-core-backend");
 const Sistema = require("./models/Sistema");
 const getOrigin = async () => (await Sistema.findOne())?.appKey;
@@ -23,7 +19,7 @@ const {
 const IntegracaoController = require("./controllers/integracao");
 const MoedaController = require("./controllers/moeda");
 
-const app = createApp();
+const app = createApp({ autoRouters: true });
 
 app.use(express.static(path.join(__dirname, "public")));
 
@@ -69,7 +65,6 @@ app.use(
 );
 // app.use("/baseomies", require("./routers/baseOmieRouter"));
 // app.use("/aprovacoes", require("./routers/aprovacaoRouter"));
-app.use("/etapas", etapaRouter);
 // app.use("/esteiras", require("./routers/esteiraRouter"));
 
 // app.use("/logs", require("./routers/logRouter"));
@@ -79,12 +74,9 @@ app.use(
   "/documentos-cadastrais",
   require("./routers/documentoCadastralRouter")
 );
-app.use("/registros", controleAlteracaoRouter);
-app.use("/listas", listaRouter);
 // app.use("/estados", require("./routers/estadoRouter"));
 // app.use("/bancos", require("./routers/bancoRouter"));
 app.use("/planejamento", require("./routers/planejamentoRouter"));
-app.use("/importacoes", importacaoRouter);
 app.use("/dashboard", require("./routers/dashboardRouter"));
 app.use("/sistema", require("./routers/sistemaRouter"));
 app.use("/lista-omie", require("./routers/listasOmieRouter"));


### PR DESCRIPTION
## Summary
- allow createApp to auto-register core routers with optional flag
- rely on automatic registration in main app

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1f8b83e50832f91ebe55cf8b5d008