### PR TITLE
refactor: expose central core routers and controllers via subpaths

### DIFF
--- a/central-oon-core-backend/package.json
+++ b/central-oon-core-backend/package.json
@@ -2,6 +2,11 @@
   "name": "central-oon-core-backend",
   "version": "0.0.2",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./controllers": "./src/controllers/index.js",
+    "./routers": "./src/routers/index.js"
+  },
   "license": "ISC",
   "dependencies": {
     "axios": "^1.7.7",

--- a/central-oon-core-backend/src/boot/createApp.js
+++ b/central-oon-core-backend/src/boot/createApp.js
@@ -29,10 +29,12 @@ function createApp({ middlewares = [], routers = [], autoRouters = true } = {}) 
   middlewares.forEach((mw) => app.use(mw));
 
   if (autoRouters) {
-    const controleAlteracaoRouter = require('../routers/controleAlteracaoRouter');
-    const importacaoRouter = require('../routers/importacaoRouter');
-    const listaRouter = require('../routers/listaRouter');
-    const etapaRouter = require('../routers/etapaRouter');
+    const {
+      controleAlteracaoRouter,
+      importacaoRouter,
+      listaRouter,
+      etapaRouter,
+    } = require('../routers');
 
     routers.push(
       { path: '/registros', router: controleAlteracaoRouter },

--- a/central-oon-core-backend/src/controllers/index.js
+++ b/central-oon-core-backend/src/controllers/index.js
@@ -1,0 +1,11 @@
+const controleAlteracaoController = require('./controleAlteracao');
+const importacaoController = require('./importacao');
+const listaController = require('./lista');
+const etapaController = require('./etapa');
+
+module.exports = {
+  controleAlteracaoController,
+  importacaoController,
+  listaController,
+  etapaController,
+};

--- a/central-oon-core-backend/src/index.js
+++ b/central-oon-core-backend/src/index.js
@@ -16,14 +16,6 @@ const ControleAlteracao = require('./models/ControleAlteracao');
 const Importacao = require('./models/Importacao');
 const Lista = require('./models/Lista');
 const Etapa = require('./models/Etapa');
-const controleAlteracaoController = require('./controllers/controleAlteracao');
-const importacaoController = require('./controllers/importacao');
-const listaController = require('./controllers/lista');
-const etapaController = require('./controllers/etapa');
-const controleAlteracaoRouter = require('./routers/controleAlteracaoRouter');
-const importacaoRouter = require('./routers/importacaoRouter');
-const listaRouter = require('./routers/listaRouter');
-const etapaRouter = require('./routers/etapaRouter');
 const ControleAlteracaoService = require('./services/controleAlteracao');
 const ImportacaoService = require('./services/importacao');
 const ListaService = require('./services/lista');
@@ -54,18 +46,10 @@ module.exports = {
     Importacao,
     Lista,
     Etapa,
-    controleAlteracaoController,
-    importacaoController,
-    listaController,
-    etapaController,
     ControleAlteracaoService,
     ImportacaoService,
     ListaService,
     EtapaService,
-    controleAlteracaoRouter,
-    importacaoRouter,
-    listaRouter,
-    etapaRouter,
     sendErrorResponse,
     helpers,
     excel,

--- a/central-oon-core-backend/src/routers/index.js
+++ b/central-oon-core-backend/src/routers/index.js
@@ -1,0 +1,11 @@
+const controleAlteracaoRouter = require('./controleAlteracaoRouter');
+const importacaoRouter = require('./importacaoRouter');
+const listaRouter = require('./listaRouter');
+const etapaRouter = require('./etapaRouter');
+
+module.exports = {
+  controleAlteracaoRouter,
+  importacaoRouter,
+  listaRouter,
+  etapaRouter,
+};


### PR DESCRIPTION
## Summary
- split core controllers into `controllers/index.js`
- split core routers into `routers/index.js`
- expose new subpaths in package exports and adjust internal loader

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1fb7db62c832f8e955f84f7d4c801