### PR TITLE
refactor: move usuario module to core

### DIFF
--- a/central-oon-core-backend/src/boot/createApp.js
+++ b/central-oon-core-backend/src/boot/createApp.js
@@ -10,7 +10,7 @@ const dotenv = require('dotenv');
 // @param {Array} [options.middlewares] - Additional middlewares to load.
 // @param {Array<{path: string, router: import('express').Router}>} [options.routers] - Routers to register.
 // @param {boolean} [options.autoRouters=true] - When true, core routers
-// (controleAlteracao, importacao, lista and etapa) are automatically
+// (controleAlteracao, importacao, lista, etapa and usuario) are automatically
 // registered on their default paths.
 function createApp({ middlewares = [], routers = [], autoRouters = true } = {}) {
   dotenv.config();
@@ -34,13 +34,15 @@ function createApp({ middlewares = [], routers = [], autoRouters = true } = {}) 
       importacaoRouter,
       listaRouter,
       etapaRouter,
+      usuarioRouter,
     } = require('../routers');
 
     routers.push(
       { path: '/registros', router: controleAlteracaoRouter },
       { path: '/importacoes', router: importacaoRouter },
       { path: '/listas', router: listaRouter },
-      { path: '/etapas', router: etapaRouter }
+      { path: '/etapas', router: etapaRouter },
+      { path: '/usuarios', router: usuarioRouter }
     );
   }
 

--- a/central-oon-core-backend/src/controllers/index.js
+++ b/central-oon-core-backend/src/controllers/index.js
@@ -2,10 +2,12 @@ const controleAlteracaoController = require('./controleAlteracao');
 const importacaoController = require('./importacao');
 const listaController = require('./lista');
 const etapaController = require('./etapa');
+const usuarioController = require('./usuario');
 
 module.exports = {
   controleAlteracaoController,
   importacaoController,
   listaController,
   etapaController,
+  usuarioController,
 };

--- a/central-oon-core-backend/src/controllers/usuario.js
+++ b/central-oon-core-backend/src/controllers/usuario.js
@@ -1,12 +1,15 @@
-const UsuarioService = require("../../services/usuario");
-const Usuario = require("../../models/Usuario");
+const path = require("path");
+const UsuarioService = require("../services/usuario");
+const Usuario = require("../models/Usuario");
 const bcrypt = require("bcryptjs");
-const emailUtils = require("../../utils/emailUtils");
+const emailUtils = require(path.join(process.cwd(), "src", "utils", "emailUtils"));
 const jwt = require("jsonwebtoken");
 
 const {
-  helpers: { sendErrorResponse, sendPaginatedResponse, sendResponse },
-} = require("central-oon-core-backend");
+  sendErrorResponse,
+  sendPaginatedResponse,
+  sendResponse,
+} = require("../utils/helpers");
 
 const criarUsuario = async (req, res) => {
   const usuario = await UsuarioService.criar({ usuario: req.body });
@@ -23,7 +26,6 @@ const atualizarUsuario = async (req, res) => {
     id: req.params.id,
     usuario: req.body,
   });
-
   sendResponse({ res, statusCode: 200, usuario });
 };
 
@@ -50,7 +52,6 @@ const loginUsuario = async (req, res) => {
 };
 
 const validarToken = async (req, res) => {
-  // Se passou pelo middleware, `req.usuario` já está preenchido
   sendResponse({ res, statusCode: 200, usuario: req.usuario });
 };
 
@@ -65,10 +66,9 @@ const esqueciMinhaSenha = async (req, res) => {
       ? process.env.BASE_URL_APP_PUBLISHER
       : process.env.BASE_URL_CST;
 
-  const path =
-    usuario.tipo === "prestador" ? "/recover-password" : "/alterar-senha";
+  const pathUrl = usuario.tipo === "prestador" ? "/recover-password" : "/alterar-senha";
 
-  const url = new URL(path, baseUrl);
+  const url = new URL(pathUrl, baseUrl);
   url.searchParams.append("code", token);
 
   await emailUtils.emailEsqueciMinhaSenha({
@@ -183,13 +183,12 @@ const alterarSenha = async (req, res) => {
 const listarUsuarios = async (req, res) => {
   const { pageIndex, pageSize, searchTerm, ...rest } = req.query;
 
-  const { limite, page, totalDeUsuarios, usuarios } =
-    await UsuarioService.listarComPaginacao({
-      filtros: rest,
-      pageIndex,
-      pageSize,
-      searchTerm,
-    });
+  const { limite, page, totalDeUsuarios, usuarios } = await UsuarioService.listarComPaginacao({
+    filtros: rest,
+    pageIndex,
+    pageSize,
+    searchTerm,
+  });
 
   sendPaginatedResponse({
     res,

--- a/central-oon-core-backend/src/errors/usuario/credenciaisInvalidas.js
+++ b/central-oon-core-backend/src/errors/usuario/credenciaisInvalidas.js
@@ -1,4 +1,4 @@
-const GenericError = require("../generic");
+const GenericError = require("../GenericError");
 
 class CredenciaisInvalidasError extends GenericError {
   constructor() {

--- a/central-oon-core-backend/src/errors/usuario/usuarioNaoEncontrado.js
+++ b/central-oon-core-backend/src/errors/usuario/usuarioNaoEncontrado.js
@@ -1,4 +1,4 @@
-const GenericError = require("../generic");
+const GenericError = require("../GenericError");
 
 class UsuarioNaoEncontradoError extends GenericError {
   constructor() {

--- a/central-oon-core-backend/src/index.js
+++ b/central-oon-core-backend/src/index.js
@@ -16,10 +16,14 @@ const ControleAlteracao = require('./models/ControleAlteracao');
 const Importacao = require('./models/Importacao');
 const Lista = require('./models/Lista');
 const Etapa = require('./models/Etapa');
+const Usuario = require('./models/Usuario');
+const { usuarioController } = require('./controllers');
+const { usuarioRouter } = require('./routers');
 const ControleAlteracaoService = require('./services/controleAlteracao');
 const ImportacaoService = require('./services/importacao');
 const ListaService = require('./services/lista');
 const EtapaService = require('./services/etapa');
+const UsuarioService = require('./services/usuario');
 const { registrarAcao } = require('./services/controleService');
 const { sendErrorResponse } = require('./utils/response');
 const helpers = require('./utils/helpers');
@@ -46,10 +50,14 @@ module.exports = {
     Importacao,
     Lista,
     Etapa,
+    Usuario,
     ControleAlteracaoService,
     ImportacaoService,
     ListaService,
     EtapaService,
+    UsuarioService,
+    usuarioController,
+    usuarioRouter,
     sendErrorResponse,
     helpers,
     excel,

--- a/central-oon-core-backend/src/models/Usuario.js
+++ b/central-oon-core-backend/src/models/Usuario.js
@@ -42,7 +42,7 @@ UsuarioSchema.pre("save", async function (next) {
 UsuarioSchema.methods.gerarToken = function () {
   return jwt.sign({ id: this._id }, process.env.JWT_SECRET, {
     expiresIn: "24h",
-  }); // Token expira em 24 horas
+  });
 };
 
 module.exports = mongoose.model("Usuario", UsuarioSchema);

--- a/central-oon-core-backend/src/routers/index.js
+++ b/central-oon-core-backend/src/routers/index.js
@@ -2,10 +2,12 @@ const controleAlteracaoRouter = require('./controleAlteracaoRouter');
 const importacaoRouter = require('./importacaoRouter');
 const listaRouter = require('./listaRouter');
 const etapaRouter = require('./etapaRouter');
+const usuarioRouter = require('./usuarioRouter');
 
 module.exports = {
   controleAlteracaoRouter,
   importacaoRouter,
   listaRouter,
   etapaRouter,
+  usuarioRouter,
 };

--- a/central-oon-core-backend/src/routers/usuarioRouter.js
+++ b/central-oon-core-backend/src/routers/usuarioRouter.js
@@ -1,11 +1,10 @@
 const express = require("express");
-const UsuarioController = require("../controllers/usuario");
-const { registrarAcaoMiddleware } = require("central-oon-core-backend");
-const { ACOES, ENTIDADES } = require("../constants/controleAlteracao");
+const path = require("path");
 const router = express.Router();
-const {
-  helpers: { asyncHandler },
-} = require("central-oon-core-backend");
+const UsuarioController = require("../controllers/usuario");
+const registrarAcaoMiddleware = require("../middlewares/registrarAcaoMiddleware");
+const { asyncHandler } = require("../utils/helpers");
+const { ACOES, ENTIDADES } = require(path.join(process.cwd(), "src", "constants", "controleAlteracao"));
 
 router.get("/", asyncHandler(UsuarioController.listarUsuarios));
 

--- a/central-oon-core-backend/src/services/controleAlteracao/index.js
+++ b/central-oon-core-backend/src/services/controleAlteracao/index.js
@@ -2,7 +2,7 @@ const path = require('path');
 const ControleAlteracao = require('../../models/ControleAlteracao');
 const FiltersUtils = require('../../utils/pagination/filter');
 const PaginationUtils = require('../../utils/pagination');
-const Usuario = require(path.join(process.cwd(), 'src', 'models', 'Usuario'));
+const Usuario = require('../../models/Usuario');
 
 const buscarIdsUsuariosFiltrados = async ({ nome, searchTerm }) => {
   if (!nome && !searchTerm) return [];

--- a/central-oon-core-backend/src/services/usuario/index.js
+++ b/central-oon-core-backend/src/services/usuario/index.js
@@ -1,11 +1,9 @@
 const Usuario = require("../../models/Usuario");
-const CredenciaisInvalidasError = require("../errors/usuario/credenciaisInvalidas");
-const UsuarioNaoEncontradoError = require("../errors/usuario/usuarioNaoEncontrado");
+const CredenciaisInvalidasError = require("../../errors/usuario/credenciaisInvalidas");
+const UsuarioNaoEncontradoError = require("../../errors/usuario/usuarioNaoEncontrado");
 const bcrypt = require("bcryptjs");
-const {
-  filters: FiltersUtils,
-  pagination: PaginationUtils,
-} = require("central-oon-core-backend");
+const FiltersUtils = require("../../utils/pagination/filter");
+const PaginationUtils = require("../../utils/pagination");
 
 const criar = async ({ usuario }) => {
   const novoUsuario = new Usuario(usuario);
@@ -50,13 +48,7 @@ const login = async ({ email, senha }) => {
   return usuario;
 };
 
-const listarComPaginacao = async ({
-  pageIndex,
-  pageSize,
-  searchTerm,
-  filtros,
-  ...rest
-}) => {
+const listarComPaginacao = async ({ pageIndex, pageSize, searchTerm, filtros, ...rest }) => {
   const schema = Usuario.schema;
   const camposBusca = ["status", "nome", "email", "tipo"];
 

--- a/src/app.js
+++ b/src/app.js
@@ -55,8 +55,6 @@ app.get("/image/:filename", (req, res) => {
 
 app.use(authMiddleware({ getOrigin }));
 app.use(logMiddleware);
-
-app.use("/usuarios", require("./routers/usuarioRouter"));
 app.use("/pessoas", require("./routers/pessoaRouter"));
 app.use("/arquivos", require("./routers/arquivoRouter"));
 app.use(

--- a/src/routers/authRouter.js
+++ b/src/routers/authRouter.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = express.Router();
-const UsuarioController = require("../controllers/usuario");
+const { usuarioController: UsuarioController } = require("central-oon-core-backend");
 const { authMiddleware } = require("central-oon-core-backend");
 const {
   helpers: { asyncHandler },

--- a/src/routers/seedRouter.js
+++ b/src/routers/seedRouter.js
@@ -2,7 +2,6 @@ const express = require("express");
 const router = express.Router();
 
 const BaseOmie = require("../models/BaseOmie");
-const Usuario = require("../models/Usuario");
 // const Banco = require("../models/Banco");
 // const Estado = require("../models/Estado");
 const { Etapa } = require("central-oon-core-backend");


### PR DESCRIPTION
## Summary
- abstract usuario model, service, controller, and router into core package
- expose core usuario router and controller for reuse
- update controleAlteracao service and app to use core usuario module
- auto-register usuario router via core autoRouters

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1fec13e6c832fb1bffc974f4f2c26