### PR TITLE
refactor: move email util to core

### DIFF
--- a/central-oon-core-backend/package.json
+++ b/central-oon-core-backend/package.json
@@ -15,6 +15,7 @@
     "winston": "^3.17.0",
     "archiver": "^7.0.1",
     "xlsx": "^0.18.5",
-    "date-fns": "^4.1.0"
+    "date-fns": "^4.1.0",
+    "@sendgrid/mail": "^8.1.3"
   }
 }

--- a/central-oon-core-backend/src/controllers/usuario.js
+++ b/central-oon-core-backend/src/controllers/usuario.js
@@ -1,8 +1,7 @@
-const path = require("path");
 const UsuarioService = require("../services/usuario");
 const Usuario = require("../models/Usuario");
 const bcrypt = require("bcryptjs");
-const emailUtils = require(path.join(process.cwd(), "src", "utils", "emailUtils"));
+const email = require("../utils/email");
 const jwt = require("jsonwebtoken");
 
 const {
@@ -71,7 +70,7 @@ const esqueciMinhaSenha = async (req, res) => {
   const url = new URL(pathUrl, baseUrl);
   url.searchParams.append("code", token);
 
-  await emailUtils.emailEsqueciMinhaSenha({
+  await email.emailEsqueciMinhaSenha({
     usuario,
     url: url.toString(),
   });

--- a/central-oon-core-backend/src/index.js
+++ b/central-oon-core-backend/src/index.js
@@ -31,6 +31,7 @@ const excel = require('./utils/excel');
 const fileHandler = require('./utils/fileHandler');
 const pagination = require('./utils/pagination');
 const filters = require('./utils/pagination/filter');
+const email = require('./utils/email');
 
 module.exports = {
   createApp,
@@ -64,4 +65,5 @@ module.exports = {
     fileHandler,
     pagination,
     filters,
+    email,
 };

--- a/central-oon-core-backend/src/utils/email.js
+++ b/central-oon-core-backend/src/utils/email.js
@@ -1,6 +1,7 @@
 const sgMail = require("@sendgrid/mail");
 const { format } = require("date-fns");
-const Sistema = require("../models/Sistema");
+const path = require("path");
+const Sistema = require(path.join(process.cwd(), "src", "models", "Sistema"));
 // const { conviteTemplate } = require("../constants/template");
 
 const enviarEmail = async (emailTo, assunto, corpo, anexos = []) => {

--- a/src/controllers/sistema/index.js
+++ b/src/controllers/sistema/index.js
@@ -1,5 +1,5 @@
 const Sistema = require("../../models/Sistema");
-const { emailTeste } = require("../../utils/emailUtils");
+const { email } = require("central-oon-core-backend");
 
 listarSistemaConfig = async (req, res) => {
   const sistema = await Sistema.findOne();
@@ -30,7 +30,7 @@ atualizarSistemaConfig = async (req, res) => {
 };
 
 testeEmail = async (req, res) => {
-  await emailTeste({ email: req.body.email });
+  await email.emailTeste({ email: req.body.email });
   res.status(200).json();
 };
 


### PR DESCRIPTION
## Summary
- move email utility into core package and export it
- use core email utility in controllers

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c204e09760832f8fee66cd5fe539b4