### PR TITLE
feat: expose default list codes in codes endpoint

### DIFF
--- a/central-oon-core-backend/src/services/lista/index.js
+++ b/central-oon-core-backend/src/services/lista/index.js
@@ -1,4 +1,7 @@
 const Lista = require('../../models/Lista');
+const path = require('path');
+const ListaOmie = require(path.join(process.cwd(), 'src', 'models', 'ListaOmie'));
+const { LISTAS } = require(path.join(process.cwd(), 'src', 'constants', 'listas'));
 const GenericError = require('../../errors/GenericError');
 const ListaNaoEncontradaError = require('../../errors/lista/listaNaoEncontrada');
 const { validarMoedaExistente } = require('./validations');
@@ -68,7 +71,11 @@ const atualizarItem = async ({ codigo, itemId, valor }) => {
 };
 
 const listarCodigoDeListas = async () => {
-  return await Lista.distinct('codigo');
+  const codigos = await Lista.distinct('codigo');
+  const codigosOmie = await ListaOmie.distinct('codigo');
+  return Array.from(
+    new Set([...(LISTAS || []), ...codigos, ...codigosOmie])
+  );
 };
 
 module.exports = {

--- a/src/constants/listas.js
+++ b/src/constants/listas.js
@@ -1,0 +1,9 @@
+exports.LISTAS = [
+  'campanha',
+  'grupo',
+  'tipo-documento-cadastral',
+  'tipo-documento-fiscal',
+  'motivo-recusa-documento-fiscal',
+  'motivo-recusa-documento-cadastral',
+  'tipo-servico-tomado',
+];


### PR DESCRIPTION
## Summary
- declare template list codes constant
- include template codes in `GET /listas/codigos`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c816a97b90832f89bfe154040dc589